### PR TITLE
Rename `-solidity-version` parameter suffix with `-contracts-version`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,11 @@ jobs:
             ]
 
           query: |
-              keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version
+              keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
               keep-core-version = github.com/keep-network/keep-core#version
 
       # Verify outputs of the previous step.
-      - name: Validate `keep-core-solidity-version`
-        run: exit $(expr "${{ steps.upstream-builds-query.outputs.keep-core-solidity-version }}" != "1.2.3-rc.0+feature.123sda")
+      - name: Validate `keep-core-contracts-version`
+        run: exit $(expr "${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}" != "1.2.3-rc.0+feature.123sda")
       - name: Validate `keep-core-version`
         run: exit $(expr "${{ steps.upstream-builds-query.outputs.keep-core-version }}" != "b454cc275c8d3d0e609639cd85244a099fa8ee69")

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
     upstream-builds: ${{ github.event.inputs.upstream_builds }}
     fail-on-empty: false # default: true
     query: |
-        keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version
-        tbtc-solidity-version = github.com/keep-network/tbtc/solidity#version
+        keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+        tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 ```
 <!-- prettier-ignore-end -->
 
@@ -31,10 +31,10 @@ Example usage:
   with:
     upstream-builds: ${{ github.event.inputs.upstream_builds }}
     query: |
-        keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version
-        tbtc-solidity-version = github.com/keep-network/tbtc/solidity#version
+        keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+        tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 - name: Print resolved version
   run: |
-    echo "Resolved version: ${{ steps.upstream-builds-query.outputs.keep-core-solidity-version }}"
-    echo "Resolved version: ${{ steps.upstream-builds-query.outputs.tbtc-solidity-version }}"
+    echo "Resolved version: ${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}"
+    echo "Resolved version: ${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}"
 ```

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -32,10 +32,10 @@ describe("main", function () {
   describe("execute", () => {
     it("finds value for single query", async () => {
       const queriesString =
-        "keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version"
+        "keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version"
 
       const expectedResult = {
-        "keep-core-solidity-version": "1.2.3-rc.0+feature.123asd",
+        "keep-core-contracts-version": "1.2.3-rc.0+feature.123asd",
       }
 
       const result = execute(upstreamBuildsString, queriesString)
@@ -45,12 +45,12 @@ describe("main", function () {
 
     it("finds values for multiple queries", async () => {
       const queriesString = [
-        "keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version",
+        "keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version",
         "keep-core-version = github.com/keep-network/keep-core#version",
       ]
 
       const expectedResult = {
-        "keep-core-solidity-version": "1.2.3-rc.0+feature.123asd",
+        "keep-core-contracts-version": "1.2.3-rc.0+feature.123asd",
         "keep-core-version": "b454cc275c8d3d0e609639cd85244a099fa8ee69",
       }
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -5,13 +5,13 @@ describe("query", function () {
   describe("parseQuery", () => {
     it("parses single query", async () => {
       const string =
-        "keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version"
+        "keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version"
 
       const expectedResult = [
         {
           module: "github.com/keep-network/keep-core/solidity",
           property: "version",
-          output: "keep-core-solidity-version",
+          output: "keep-core-contracts-version",
         },
       ]
 
@@ -22,7 +22,7 @@ describe("query", function () {
 
     it("parses array of queries", async () => {
       const string = [
-        "keep-core-solidity-version = github.com/keep-network/keep-core/solidity#version",
+        "keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version",
         "keep-core-version=github.com/keep-network/keep-core#version",
       ]
 
@@ -30,7 +30,7 @@ describe("query", function () {
         {
           module: "github.com/keep-network/keep-core/solidity",
           property: "version",
-          output: "keep-core-solidity-version",
+          output: "keep-core-contracts-version",
         },
         {
           module: "github.com/keep-network/keep-core",


### PR DESCRIPTION
Change introduced for better understandability of parameter's meaning.

Refs:
https://github.com/keep-network/keep-core/pull/2532
https://github.com/keep-network/keep-ecdsa/pull/864
https://github.com/keep-network/tbtc/pull/814
https://github.com/keep-network/tbtc.js/pull/127
https://github.com/keep-network/coverage-pools/pull/157